### PR TITLE
Adds new command for previewing output in plaintext

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "shopify-liquid-preview",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
         "Live Preview"
     ],
     "activationEvents": [
-        "onCommand:shopifyLiquidPreview.preview"
+        "onCommand:shopifyLiquidPreview.preview",
+        "onCommand:shopifyLiquidPreview.previewText"
     ],
     "main": "./out/src/extension",
     "contributes": {
@@ -34,6 +35,10 @@
             {
                 "command": "shopifyLiquidPreview.preview",
                 "title": "Shopify Liquid: Open Preview"
+            },
+            {
+                "command": "shopifyLiquidPreview.previewText",
+                "title": "Shopify Liquid: Open Preview (Plaintext)"
             }
         ],
         "keybindings": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import {
 import PreviewContentProvider from './lib/PreviewContentProvider';
 import PREVIEW_URL from './lib/PREVIEW_URI';
 import preview from './lib/preview';
+import previewText from './lib/previewText';
 
 export function activate(context: ExtensionContext) {
 
@@ -28,7 +29,8 @@ export function activate(context: ExtensionContext) {
         }),
 
         // Commands
-        commands.registerCommand('shopifyLiquidPreview.preview', preview)
+        commands.registerCommand('shopifyLiquidPreview.preview', preview),
+        commands.registerCommand('shopifyLiquidPreview.previewText', previewText)
     );
 }
 

--- a/src/lib/previewText.ts
+++ b/src/lib/previewText.ts
@@ -1,0 +1,10 @@
+import {
+    workspace, window, commands,
+    ViewColumn
+} from "vscode";
+
+import PREVIEW_URI from "./PREVIEW_URI";
+
+export default () => {
+    return commands.executeCommand("vscode.open", PREVIEW_URI, ViewColumn.Two, "Shopify Liquid Plaintext Preview");
+}


### PR DESCRIPTION
I'm using Liquid to generate non-HTML content, and therefore the HTML view was corrupting the output.

I've added a command to show the raw, plaintext version of the output.